### PR TITLE
Use root account for remote user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Zuerst möchte ich einen Client remote updaten und den user "dto" anlegen.
 
 ## Verwendung
 
-Das Inventory `inventory/hosts.ini` beinhaltet den Zielhost `192.168.188.92`.
+Das Inventory `inventory/hosts.ini` beinhaltet den Zielhost `192.168.188.92` und nutzt den Benutzer `root` für die Verbindung.
 
 Das Playbook `dto_user.yml` legt den Benutzer `dto` an, erstellt ein Homeverzeichnis,
 fügt ihn der Gruppe `sudo` hinzu und erzwingt eine Passwortänderung beim ersten Login.

--- a/dto_user.yml
+++ b/dto_user.yml
@@ -1,7 +1,6 @@
 ---
 - name: Manage remote Debian client
   hosts: debian
-  become: true
   tasks:
     - name: Ensure dto user exists with sudo privileges
       ansible.builtin.user:

--- a/inventory/hosts.ini
+++ b/inventory/hosts.ini
@@ -1,2 +1,2 @@
 [debian]
-192.168.188.92
+192.168.188.92 ansible_user=root


### PR DESCRIPTION
## Summary
- connect to target host as root via inventory
- run user management tasks directly as root
- document root usage in README

## Testing
- `ansible-playbook --syntax-check -i inventory/hosts.ini dto_user.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68971e0dc93483338202573a12bb5575