### PR TITLE
Use root account for remote user creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ Zuerst möchte ich einen Client remote updaten und den user "dto" anlegen.
 
 ## Verwendung
 
-Das Inventory `inventory/hosts.ini` beinhaltet den Zielhost `192.168.188.92`.
+Das Inventory `inventory/hosts.ini` beinhaltet den Zielhost `192.168.188.92` und nutzt den Benutzer `root` für die Verbindung.
 
 Das Playbook `dto_user.yml` legt den Benutzer `dto` an, erstellt ein Homeverzeichnis,
 fügt ihn der Gruppe `sudo` hinzu und erzwingt eine Passwortänderung beim ersten Login.
+Zudem setzt es `/bin/bash` als Standardshell und installiert eine farbige Prompt,
+die IP-Adresse, Benutzername und aktuelles Verzeichnis in unterschiedlichen Farben anzeigt.
 
 Playbook ausführen:
 

--- a/dto_user.yml
+++ b/dto_user.yml
@@ -1,7 +1,6 @@
 ---
 - name: Manage remote Debian client
   hosts: debian
-  become: true
   tasks:
     - name: Ensure dto user exists with sudo privileges
       ansible.builtin.user:
@@ -10,6 +9,14 @@
         append: true
         create_home: true
         password: "{{ 'dto' | password_hash('sha512') }}"
+        shell: /bin/bash
     - name: Force dto to change password on first login
       ansible.builtin.command:
         cmd: chage -d 0 dto
+    - name: Deploy colorful bashrc for dto user
+      ansible.builtin.template:
+        src: templates/bashrc.j2
+        dest: /home/dto/.bashrc
+        owner: dto
+        group: dto
+        mode: '0644'

--- a/inventory/hosts.ini
+++ b/inventory/hosts.ini
@@ -1,2 +1,2 @@
 [debian]
-192.168.188.92
+192.168.188.92 ansible_user=root

--- a/templates/bashrc.j2
+++ b/templates/bashrc.j2
@@ -1,0 +1,9 @@
+# .bashrc for dto user (Ansible managed)
+# If not running interactively, exit
+case $- in
+    *i*) ;;
+      *) return;;
+esac
+# Colourful prompt with host IP, username, and current directory
+IP="$(hostname -I | awk '{print $1}')"
+PS1="\[\e[36m\]${IP}\[\e[0m\] \[\e[32m\]\u\[\e[0m\] \[\e[34m\]\w\[\e[0m\]\$ "


### PR DESCRIPTION
## Summary
- connect to target host as root via inventory
- run user management tasks directly as root
- set `/bin/bash` as default shell for `dto` and deploy a colorful prompt via `.bashrc`
- fix prompt template so host IP is dynamically resolved instead of showing raw command text
- document shell and prompt setup in README

## Testing
- `ansible-playbook --syntax-check -i inventory/hosts.ini dto_user.yml` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*
- `python3 -m pip install --user ansible` *(fails: 403 Forbidden through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68971e0dc93483338202573a12bb5575