### PR TITLE
Fix IP prompt evaluation for dto user

### DIFF
--- a/templates/bashrc.j2
+++ b/templates/bashrc.j2
@@ -5,5 +5,4 @@ case $- in
       *) return;;
 esac
 # Colourful prompt with host IP, username, and current directory
-IP="$(hostname -I | awk '{print $1}')"
-PS1="\[\e[36m\]${IP}\[\e[0m\] \[\e[32m\]\u\[\e[0m\] \[\e[34m\]\w\[\e[0m\]\$ "
+PS1="\[\e[36m\]$(hostname -I | awk '{print $1}')\[\e[0m\] \[\e[32m\]\u\[\e[0m\] \[\e[34m\]\w\[\e[0m\]\$ "


### PR DESCRIPTION
## Summary
- Inline host IP lookup in PS1 so bash prompt shows the evaluated IP rather than the command itself

## Testing
- `apt-get update` *(fails: The repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed)*
- `pip install ansible` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6897482b6c0083338f6647671cdb10bf