### PR TITLE
Fix IP prompt evaluation for dto user

### DIFF
--- a/templates/bashrc.j2
+++ b/templates/bashrc.j2
@@ -5,5 +5,4 @@ case $- in
       *) return;;
 esac
 # Colourful prompt with host IP, username, and current directory
-IP="$(hostname -I | awk '{print $1}')"
-PS1="\[\e[36m\]${IP}\[\e[0m\] \[\e[32m\]\u\[\e[0m\] \[\e[34m\]\w\[\e[0m\]\$ "
+PS1='\\[\\e[36m\\]$(hostname -I | cut -d" " -f1)\\[\\e[0m\\] \\[\\e[32m\\]\\u\\[\\e[0m\\] \\[\\e[34m\\]\\w\\[\\e[0m\\]\\$ '


### PR DESCRIPTION
## Summary
- Switch PS1 to a single-quoted command substitution so the prompt evaluates on display
- Replace awk with cut to avoid quoting issues while showing first host IP

## Testing
- `ansible-playbook --syntax-check dto_user.yml` *(fails: command not found: ansible-playbook)*

------
https://chatgpt.com/codex/tasks/task_e_6897482b6c0083338f6647671cdb10bf