### PR TITLE
Fix IP prompt evaluation for dto user

### DIFF
--- a/templates/bashrc.j2
+++ b/templates/bashrc.j2
@@ -4,6 +4,7 @@ case $- in
     *i*) ;;
       *) return;;
 esac
+# Ensure prompt variables are expanded
+shopt -s promptvars
 # Colourful prompt with host IP, username, and current directory
-IP="$(hostname -I | awk '{print $1}')"
-PS1="\[\e[36m\]${IP}\[\e[0m\] \[\e[32m\]\u\[\e[0m\] \[\e[34m\]\w\[\e[0m\]\$ "
+PS1='\\[\\e[36m\\]$(hostname -I | cut -d" " -f1)\\[\\e[0m\\] \\[\\e[32m\\]\\u\\[\\e[0m\\] \\[\\e[34m\\]\\w\\[\\e[0m\\]\\$ '


### PR DESCRIPTION
## Summary
- Ensure bash prompt executes command substitution by enabling `promptvars`
- Keep coloured PS1 showing first host IP, username, and current directory

## Testing
- `ansible-playbook --syntax-check dto_user.yml` *(fails: command not found: ansible-playbook)*
- `pip install ansible` *(fails: Tunnel connection failed: 403 Forbidden)*
- `apt-get update` *(fails: 403 Forbidden, repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6897482b6c0083338f6647671cdb10bf