### PR TITLE
Fix bash prompt and update ironscope user references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # dto_admin
 Hier werden Playbooks gesammelt, die einen Remote Client manipulieren können.
-Zuerst möchte ich einen Client remote updaten und den user "dto" anlegen.
+Zuerst möchte ich einen Client remote updaten und den user "ironscope" anlegen.
 
 ## Verwendung
 
-Das Inventory `inventory/hosts.ini` beinhaltet den Zielhost `192.168.188.92` und nutzt den Benutzer `root` für die Verbindung.
+Das Inventory `inventory/hosts.ini` beinhaltet den Zielhost `192.168.188.121` und nutzt den Benutzer `root` für die Verbindung.
 
-Das Playbook `dto_user.yml` legt den Benutzer `dto` an, erstellt ein Homeverzeichnis,
+Das Playbook `dto_user.yml` legt den Benutzer `ironscope` an, erstellt ein Homeverzeichnis,
 fügt ihn der Gruppe `sudo` hinzu und erzwingt eine Passwortänderung beim ersten Login.
 Zudem setzt es `/bin/bash` als Standardshell und installiert eine farbige Prompt,
 die IP-Adresse, Benutzername und aktuelles Verzeichnis in unterschiedlichen Farben anzeigt.

--- a/dto_user.yml
+++ b/dto_user.yml
@@ -10,10 +10,10 @@
         create_home: true
         password: "{{ 'iron' | password_hash('sha512') }}"
         shell: /bin/bash
-    - name: Force dto to change password on first login
+    - name: Force ironscope to change password on first login
       ansible.builtin.command:
         cmd: chage -d 0 ironscope
-    - name: Deploy colorful bashrc for dto user
+    - name: Deploy colorful bashrc for ironscope user
       ansible.builtin.template:
         src: templates/bashrc.j2
         dest: /home/ironscope/.bashrc

--- a/templates/bashrc.j2
+++ b/templates/bashrc.j2
@@ -1,4 +1,4 @@
-# .bashrc for dto user (Ansible managed)
+# .bashrc for ironscope user (Ansible managed)
 # If not running interactively, exit
 case $- in
     *i*) ;;
@@ -7,4 +7,4 @@ esac
 # Ensure prompt variables are expanded
 shopt -s promptvars
 # Colourful prompt with host IP, username, and current directory
-PS1='\\[\\e[36m\\]$(hostname -I | cut -d" " -f1)\\[\\e[0m\\] \\[\\e[32m\\]\\u\\[\\e[0m\\] \\[\\e[34m\\]\\w\\[\\e[0m\\]\\$ '
+PS1='\[\e[36m\]$(hostname -I | cut -d" " -f1)\[\e[0m\] \[\e[32m\]\u\[\e[0m\] \[\e[34m\]\w\[\e[0m\]\$ '


### PR DESCRIPTION
## Summary
- update documentation to reflect ironscope user and new host IP
- adjust playbook task names for ironscope
- fix bashrc template for proper colored prompt

## Testing
- `ansible-playbook --syntax-check -i inventory/hosts.ini dto_user.yml` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6898367662f48333bcca6edb0b7854d0