### PR TITLE
Install rclone and create user onedrive directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Das Inventory `inventory/hosts.ini` beinhaltet den Zielhost `192.168.188.121` un
 
 Das Playbook `dto_user.yml` legt den Benutzer `ironscope` an, erstellt ein Homeverzeichnis,
 fügt ihn der Gruppe `sudo` hinzu und erzwingt eine Passwortänderung beim ersten Login.
-Zudem setzt es `/bin/bash` als Standardshell und installiert eine farbige Prompt,
+Zusätzlich installiert es das Paket `rclone`, legt im Homeverzeichnis den Ordner `onedrive` an
+und setzt `/bin/bash` als Standardshell. Abschließend installiert es eine farbige Prompt,
 die IP-Adresse, Benutzername und aktuelles Verzeichnis in unterschiedlichen Farben anzeigt.
 
 Playbook ausführen:

--- a/dto_user.yml
+++ b/dto_user.yml
@@ -13,6 +13,18 @@
     - name: Force ironscope to change password on first login
       ansible.builtin.command:
         cmd: chage -d 0 ironscope
+    - name: Install rclone
+      ansible.builtin.apt:
+        name: rclone
+        state: present
+        update_cache: true
+    - name: Create onedrive directory for ironscope
+      ansible.builtin.file:
+        path: /home/ironscope/onedrive
+        state: directory
+        owner: ironscope
+        group: ironscope
+        mode: '0755'
     - name: Deploy colorful bashrc for ironscope user
       ansible.builtin.template:
         src: templates/bashrc.j2


### PR DESCRIPTION
## Summary
- install rclone via apt
- create `onedrive` directory in ironscope's home
- document new rclone and onedrive features in README

## Testing
- `ansible-playbook -i inventory/hosts.ini --syntax-check dto_user.yml` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68983951ded88333becddffb96bab532