### PR TITLE
Make playbook idempotent and add versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,25 @@
 # dto_admin
-Hier werden Playbooks gesammelt, die einen Remote Client manipulieren können.
-Zuerst möchte ich einen Client remote updaten und den user "ironscope" anlegen.
 
-## Verwendung
+This repository collects Ansible playbooks that can manipulate a remote client.
+Currently it provides a playbook to update a client and create the user "ironscope".
 
-Das Inventory `inventory/hosts.ini` beinhaltet den Zielhost `192.168.188.121` und nutzt den Benutzer `root` für die Verbindung.
+## Usage
 
-Das Playbook `dto_user.yml` legt den Benutzer `ironscope` an, erstellt ein Homeverzeichnis,
-fügt ihn der Gruppe `sudo` hinzu und erzwingt eine Passwortänderung beim ersten Login.
-Zunächst wird das System des Zielhosts aktualisiert. Anschließend installiert das Playbook das Paket `rclone`,
-legt im Homeverzeichnis den Ordner `onedrive` an und setzt `/bin/bash` als Standardshell.
-Abschließend installiert es eine farbige Prompt, die IP-Adresse, Benutzername und aktuelles Verzeichnis
-in unterschiedlichen Farben anzeigt.
+The inventory `inventory/hosts.ini` contains the target host `192.168.188.121` and uses the user `root` for the connection.
 
-Playbook ausführen:
+The playbook `dto_user.yml` ensures that the user `ironscope` exists, creates a home directory,
+adds the user to the `sudo` group and forces a password change at the first login.
+It then updates the target host system, installs the package `rclone`,
+creates the directory `onedrive` in the home directory and sets `/bin/bash` as the default shell.
+Finally, it installs a colorful prompt that displays IP address, username and current directory
+in different colors.
+
+Run the playbook:
 
 ```bash
 ansible-playbook -i inventory/hosts.ini dto_user.yml
 ```
+
+## Versioning
+
+Current version: 0.1.0-beta. A stable 1.0.0 release will be defined in the future.

--- a/dto_user.yml
+++ b/dto_user.yml
@@ -2,6 +2,12 @@
 - name: Manage remote Debian client
   hosts: debian
   tasks:
+    - name: Check if ironscope user already exists
+      ansible.builtin.command: id -u ironscope
+      register: ironscope_user_check
+      failed_when: false
+      changed_when: false
+
     - name: Ensure ironscope user exists with sudo privileges
       ansible.builtin.user:
         name: ironscope
@@ -10,18 +16,38 @@
         create_home: true
         password: "{{ 'iron' | password_hash('sha512') }}"
         shell: /bin/bash
-    - name: Force ironscope to change password on first login
-      ansible.builtin.command:
-        cmd: chage -d 0 ironscope
+        password_expire: true
+        update_password: on_create
+      when: ironscope_user_check.rc != 0
+      register: created_ironscope_user
+
+    - name: Mark that ironscope user is available
+      ansible.builtin.set_fact:
+        ironscope_user_exists: "{{ (created_ironscope_user is defined and created_ironscope_user.changed) or (ironscope_user_check.rc == 0) }}"
+
     - name: Update system packages
       ansible.builtin.apt:
         update_cache: true
         upgrade: dist
+
+    - name: Check if rclone is installed
+      ansible.builtin.stat:
+        path: /usr/bin/rclone
+      register: rclone_binary
+
     - name: Install rclone
       ansible.builtin.apt:
         name: rclone
         state: present
         update_cache: true
+      when: not rclone_binary.stat.exists
+
+    - name: Check if onedrive directory exists
+      ansible.builtin.stat:
+        path: /home/ironscope/onedrive
+      register: onedrive_dir
+      when: ironscope_user_exists
+
     - name: Create onedrive directory for ironscope
       ansible.builtin.file:
         path: /home/ironscope/onedrive
@@ -29,6 +55,16 @@
         owner: ironscope
         group: ironscope
         mode: '0755'
+      when:
+        - ironscope_user_exists
+        - not onedrive_dir.stat.exists
+
+    - name: Check if ironscope bashrc exists
+      ansible.builtin.stat:
+        path: /home/ironscope/.bashrc
+      register: ironscope_bashrc
+      when: ironscope_user_exists
+
     - name: Deploy colorful bashrc for ironscope user
       ansible.builtin.template:
         src: templates/bashrc.j2
@@ -36,3 +72,6 @@
         owner: ironscope
         group: ironscope
         mode: '0644'
+      when:
+        - ironscope_user_exists
+        - not ironscope_bashrc.stat.exists


### PR DESCRIPTION
## Summary
- Add safeguards so playbook skips actions when the ironscope user and other artifacts already exist
- Add checks for rclone and ironscope home files to keep runs idempotent
- Translate documentation to English and introduce a beta versioning scheme

## Testing
- `ansible-playbook --syntax-check -i inventory/hosts.ini dto_user.yml` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68984ae991208333a75dc89ebff44968