### PR TITLE
Number tasks and check OneDrive directory as ironscope

### DIFF
--- a/dto_user.yml
+++ b/dto_user.yml
@@ -2,13 +2,13 @@
 - name: Manage remote Debian client
   hosts: debian
   tasks:
-    - name: Check if ironscope user already exists
+    - name: "01 Check if ironscope user already exists"
       ansible.builtin.command: id -u ironscope
       register: ironscope_user_check
       failed_when: false
       changed_when: false
 
-    - name: Ensure ironscope user exists with sudo privileges
+    - name: "02 Ensure ironscope user exists with sudo privileges"
       ansible.builtin.user:
         name: ironscope
         groups: sudo
@@ -21,34 +21,38 @@
       when: ironscope_user_check.rc != 0
       register: created_ironscope_user
 
-    - name: Mark that ironscope user is available
+    - name: "03 Mark that ironscope user is available"
       ansible.builtin.set_fact:
         ironscope_user_exists: "{{ (created_ironscope_user is defined and created_ironscope_user.changed) or (ironscope_user_check.rc == 0) }}"
 
-    - name: Update system packages
+    - name: "04 Update system packages"
       ansible.builtin.apt:
         update_cache: true
         upgrade: dist
 
-    - name: Check if rclone is installed
+    - name: "05 Check if rclone is installed"
       ansible.builtin.stat:
         path: /usr/bin/rclone
       register: rclone_binary
 
-    - name: Install rclone
+    - name: "06 Install rclone"
       ansible.builtin.apt:
         name: rclone
         state: present
         update_cache: true
       when: not rclone_binary.stat.exists
 
-    - name: Check if onedrive directory exists
+    - name: "07 Check if onedrive directory exists"
       ansible.builtin.stat:
         path: /home/ironscope/onedrive
       register: onedrive_dir
+      become: true
+      become_user: ironscope
+      failed_when: false
+      changed_when: false
       when: ironscope_user_exists
 
-    - name: Create onedrive directory for ironscope
+    - name: "08 Create onedrive directory for ironscope"
       ansible.builtin.file:
         path: /home/ironscope/onedrive
         state: directory
@@ -59,13 +63,13 @@
         - ironscope_user_exists
         - not onedrive_dir.stat.exists
 
-    - name: Check if ironscope bashrc exists
+    - name: "09 Check if ironscope bashrc exists"
       ansible.builtin.stat:
         path: /home/ironscope/.bashrc
       register: ironscope_bashrc
       when: ironscope_user_exists
 
-    - name: Deploy colorful bashrc for ironscope user
+    - name: "10 Deploy colorful bashrc for ironscope user"
       ansible.builtin.template:
         src: templates/bashrc.j2
         dest: /home/ironscope/.bashrc


### PR DESCRIPTION
## Summary
- Prefix tasks with numeric identifiers for easier reference
- Check OneDrive directory existence as `ironscope` to handle rclone mounts

## Testing
- `ansible-playbook --syntax-check dto_user.yml -i inventory/hosts.ini` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68984cf442c08333aecc5c2e72a3ca3f