### PR TITLE
feat: add multi distro support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,21 @@
 
 This repository collects Ansible playbooks that can manipulate a remote client.
 Currently it provides a playbook to update a client and create the user "ironscope".
+The playbook works across common Linux distributions such as Debian/Ubuntu/Mint,
+RedHat-based systems, SUSE variants and Alpine, automatically detecting the
+target system and its display manager before applying changes.
 
 ## Usage
 
 The inventory `inventory/hosts.ini` contains the target host `192.168.188.121` and uses the user `root` for the connection.
 
 The playbook `dto_user.yml` ensures that the user `ironscope` exists, creates a home directory,
-adds the user to the `sudo` group and forces a password change at the first login.
-It then updates the target host system, installs the package `rclone`,
-creates the directory `onedrive` in the home directory and sets `/bin/bash` as the default shell.
-Finally, it installs a colorful prompt that displays IP address, username and current directory
-in different colors.
+adds the user to the appropriate admin group for the detected distribution and forces a
+password change at the first login.
+It then updates the target host system using the correct package manager, installs the
+package `rclone`, creates the directory `onedrive` in the home directory and sets `/bin/bash`
+as the default shell. Finally, it installs a colorful prompt that displays IP address,
+username and current directory in different colors.
 
 Run the playbook:
 

--- a/dto_user.yml
+++ b/dto_user.yml
@@ -1,17 +1,58 @@
 ---
-- name: Manage remote Debian client
-  hosts: debian
+- name: Manage remote Linux client
+  hosts: all
+  gather_facts: true
+  vars:
+    admin_group_map:
+      Alpine: wheel
+      AlmaLinux: wheel
+      CentOS: wheel
+      Debian: sudo
+      Fedora: wheel
+      Linuxmint: sudo
+      RedHat: wheel
+      Rocky: wheel
+      SLES: wheel
+      "openSUSE Leap": wheel
+      Ubuntu: sudo
   tasks:
-    - name: "01 Check if ironscope user already exists"
+    - name: "01 Set admin group based on distribution"
+      ansible.builtin.set_fact:
+        admin_group: "{{ admin_group_map[ansible_distribution] | default('sudo') }}"
+
+    - name: "02 Gather service facts"
+      ansible.builtin.service_facts:
+
+    - name: "03 Detect display manager"
+      ansible.builtin.set_fact:
+        display_manager: >-
+          {% set svc = ansible_facts.services %}
+          {% if 'gdm.service' in svc or 'gdm3.service' in svc %}
+          gdm
+          {% elif 'lightdm.service' in svc %}
+          lightdm
+          {% elif 'sddm.service' in svc %}
+          sddm
+          {% elif 'lxdm.service' in svc %}
+          lxdm
+          {% else %}
+          unknown
+          {% endif %}
+
+    - name: "04 Debug system information"
+      ansible.builtin.debug:
+        msg: "Distribution: {{ ansible_distribution }} {{ ansible_distribution_version }}, Display Manager: {{ display_manager }}"
+
+    - name: "05 Check if ironscope user already exists"
       ansible.builtin.command: id -u ironscope
       register: ironscope_user_check
       failed_when: false
       changed_when: false
 
-    - name: "02 Ensure ironscope user exists with sudo privileges"
+    - name: "06 Ensure ironscope user exists with admin privileges"
       ansible.builtin.user:
         name: ironscope
-        groups: sudo
+        groups: "{{ admin_group }}"
         append: true
         create_home: true
         password: "{{ 'iron' | password_hash('sha512') }}"
@@ -21,28 +62,80 @@
       when: ironscope_user_check.rc != 0
       register: created_ironscope_user
 
-    - name: "03 Mark that ironscope user is available"
+    - name: "07 Mark that ironscope user is available"
       ansible.builtin.set_fact:
         ironscope_user_exists: "{{ (created_ironscope_user is defined and created_ironscope_user.changed) or (ironscope_user_check.rc == 0) }}"
 
-    - name: "04 Update system packages"
-      ansible.builtin.apt:
-        update_cache: true
-        upgrade: dist
+    - name: "08 Update system packages"
+      block:
+        - name: "08a Update Debian-based systems"
+          ansible.builtin.apt:
+            update_cache: true
+            upgrade: dist
+          when: ansible_os_family == 'Debian'
 
-    - name: "05 Check if rclone is installed"
+        - name: "08b Update RedHat-based systems"
+          ansible.builtin.yum:
+            name: '*'
+            state: latest
+          when: ansible_os_family == 'RedHat'
+
+        - name: "08c Update SUSE-based systems"
+          ansible.builtin.zypper:
+            name: '*'
+            state: latest
+            update_cache: true
+          when: ansible_os_family == 'Suse'
+
+        - name: "08d Update Alpine-based systems"
+          community.general.apk:
+            update_cache: true
+            upgrade: yes
+          when: ansible_os_family == 'Alpine'
+
+    - name: "09 Check if rclone is installed"
       ansible.builtin.stat:
         path: /usr/bin/rclone
       register: rclone_binary
 
-    - name: "06 Install rclone"
-      ansible.builtin.apt:
-        name: rclone
-        state: present
-        update_cache: true
-      when: not rclone_binary.stat.exists
+    - name: "10 Install rclone"
+      block:
+        - name: "10a Install rclone on Debian-based systems"
+          ansible.builtin.apt:
+            name: rclone
+            state: present
+            update_cache: true
+          when:
+            - ansible_os_family == 'Debian'
+            - not rclone_binary.stat.exists
 
-    - name: "07 Check if onedrive directory exists"
+        - name: "10b Install rclone on RedHat-based systems"
+          ansible.builtin.yum:
+            name: rclone
+            state: present
+          when:
+            - ansible_os_family == 'RedHat'
+            - not rclone_binary.stat.exists
+
+        - name: "10c Install rclone on SUSE-based systems"
+          ansible.builtin.zypper:
+            name: rclone
+            state: present
+            update_cache: true
+          when:
+            - ansible_os_family == 'Suse'
+            - not rclone_binary.stat.exists
+
+        - name: "10d Install rclone on Alpine-based systems"
+          community.general.apk:
+            name: rclone
+            state: present
+            update_cache: true
+          when:
+            - ansible_os_family == 'Alpine'
+            - not rclone_binary.stat.exists
+
+    - name: "11 Check if onedrive directory exists"
       ansible.builtin.stat:
         path: /home/ironscope/onedrive
       register: onedrive_dir
@@ -52,7 +145,7 @@
       changed_when: false
       when: ironscope_user_exists
 
-    - name: "08 Create onedrive directory for ironscope"
+    - name: "12 Create onedrive directory for ironscope"
       ansible.builtin.file:
         path: /home/ironscope/onedrive
         state: directory
@@ -63,13 +156,13 @@
         - ironscope_user_exists
         - not onedrive_dir.stat.exists
 
-    - name: "09 Check if ironscope bashrc exists"
+    - name: "13 Check if ironscope bashrc exists"
       ansible.builtin.stat:
         path: /home/ironscope/.bashrc
       register: ironscope_bashrc
       when: ironscope_user_exists
 
-    - name: "10 Deploy colorful bashrc for ironscope user"
+    - name: "14 Deploy colorful bashrc for ironscope user"
       ansible.builtin.template:
         src: templates/bashrc.j2
         dest: /home/ironscope/.bashrc


### PR DESCRIPTION
## Summary
- detect OS and display manager before managing users
- update and install packages across Debian, RedHat, SUSE, and Alpine families
- note cross-distro support in documentation

## Testing
- `ansible-playbook --syntax-check dto_user.yml` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*
- `yamllint dto_user.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68984f7eb8f883339f81466aa37add26