### PR TITLE
Add Proxmox playbook to remove subscription warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ target system and its display manager before applying changes.
 
 ## Usage
 
-The inventory `inventory/hosts.ini` contains the target host `192.168.188.121` and uses the user `root` for the connection.
+The inventory `inventory/hosts.ini` contains the Debian host `192.168.188.121` and the Proxmox host `192.168.188.150`. Both use the user `root` for the connection.
 
 The playbook `dto_user.yml` ensures that the user `ironscope` exists, creates a home directory,
 adds the user to the appropriate admin group for the detected distribution and forces a
@@ -18,10 +18,13 @@ package `rclone`, creates the directory `onedrive` in the home directory and set
 as the default shell. Finally, it installs a colorful prompt that displays IP address,
 username and current directory in different colors.
 
+The playbook `dto_proxmox.yml` disables the subscription warning on a Proxmox host by patching `/usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js` and restarting the `pveproxy` service.
+
 Run the playbook:
 
 ```bash
 ansible-playbook -i inventory/hosts.ini dto_user.yml
+ansible-playbook -i inventory/hosts.ini dto_proxmox.yml
 ```
 
 ## Versioning

--- a/dto_proxmox.yml
+++ b/dto_proxmox.yml
@@ -1,0 +1,12 @@
+---
+- name: Manage Proxmox host
+  hosts: proxmox
+  gather_facts: false
+  tasks:
+    - name: "01 Disable subscription warning"
+      # ansible.builtin.shell: run shell commands on the remote host
+      ansible.builtin.shell:
+        cmd: >-  # cmd: command executed on remote host
+          sed -Ezi.bak "s/(Ext.Msg.show\(\{\s+title: gettext\('No valid sub)/void\(\{ \/\/\1/g" /usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js &&
+          systemctl restart pveproxy.service
+

--- a/inventory/hosts.ini
+++ b/inventory/hosts.ini
@@ -1,2 +1,5 @@
 [debian]
 192.168.188.121 ansible_user=root
+
+[proxmox]
+192.168.188.150 ansible_user=root


### PR DESCRIPTION
## Summary
- add Proxmox host to inventory
- add playbook to disable Proxmox subscription warning
- document inventory and playbook usage in README

## Testing
- `ansible-playbook --syntax-check -i inventory/hosts.ini dto_proxmox.yml` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c631ce7e4833396db54a8a3efe820