### PR TITLE
Add bashrc aliases and user home setup playbook

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,2 @@
+---
+username: ironscope

--- a/dto_userhome.yml
+++ b/dto_userhome.yml
@@ -1,0 +1,30 @@
+---
+- name: Prepare user home directory
+  hosts: all
+  gather_facts: false
+  vars_files:
+    - config.yml
+  tasks:
+    - name: Ensure home directory exists for {{ username }}
+      ansible.builtin.file:
+        path: "/home/{{ username }}"
+        state: directory
+        owner: "{{ username }}"
+        group: "{{ username }}"
+        mode: '0755'
+
+    - name: Ensure onedrive directory exists for {{ username }}
+      ansible.builtin.file:
+        path: "/home/{{ username }}/onedrive"
+        state: directory
+        owner: "{{ username }}"
+        group: "{{ username }}"
+        mode: '0755'
+
+    - name: Deploy bashrc template for {{ username }}
+      ansible.builtin.template:
+        src: templates/bashrc.j2
+        dest: "/home/{{ username }}/.bashrc"
+        owner: "{{ username }}"
+        group: "{{ username }}"
+        mode: '0644'

--- a/templates/bashrc.j2
+++ b/templates/bashrc.j2
@@ -8,3 +8,7 @@ esac
 shopt -s promptvars
 # Colourful prompt with host IP, username, and current directory
 PS1='\[\e[36m\]$(hostname -I | cut -d" " -f1)\[\e[0m\] \[\e[32m\]\u\[\e[0m\] \[\e[34m\]\w\[\e[0m\]\$ '
+
+# Convenience aliases for running Ansible playbooks
+alias admin='ansible-playbook -i inventory/hosts.ini dto_user.yml'
+alias prox='ansible-playbook -i inventory/hosts.ini dto_proxmox.yml'


### PR DESCRIPTION
## Summary
- add aliases for playbook execution to ironscope's bashrc template
- centralize username in `config.yml`
- add `dto_userhome.yml` playbook to prepare the user home directory

## Testing
- `ansible-playbook --syntax-check dto_userhome.yml` *(fails: command not found)*
- `pip install ansible` *(fails: Could not find a version that satisfies the requirement ansible)*
- `yamllint dto_userhome.yml config.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c6d44edf88333867b1151dce1d736