### PR TITLE
Fix Proxmox network config command

### DIFF
--- a/dto_proxmox.yml
+++ b/dto_proxmox.yml
@@ -42,7 +42,7 @@
         var: storage_status.stdout_lines
 
     - name: "07 List Proxmox network configuration"
-      ansible.builtin.command: "pvesh get /nodes/$(hostname)/network"
+      ansible.builtin.command: "pvesh get /nodes/{{ ansible_hostname }}/network"
       register: network_config
       changed_when: false
 


### PR DESCRIPTION
## Summary
- use Ansible hostname variable when listing Proxmox network configuration

## Testing
- `ansible-playbook -i inventory/hosts.ini --syntax-check dto_proxmox.yml` *(fails: command not found)*
- `pip install ansible` *(fails: Could not find a version that satisfies the requirement ansible: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c6fe19fe08333aa203ac3c3c30375