### PR TITLE
Fix undefined hostname in Proxmox playbook

### DIFF
--- a/dto_proxmox.yml
+++ b/dto_proxmox.yml
@@ -1,7 +1,7 @@
 ---
 - name: Audit Proxmox host
   hosts: proxmox
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: "01 Check if subscription warning is disabled"
       ansible.builtin.shell:


### PR DESCRIPTION
## Summary
- enable fact gathering so `ansible_hostname` is defined before listing Proxmox network configuration

## Testing
- `ansible-playbook -i inventory/hosts.ini dto_proxmox.yml --syntax-check` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*
- `pip install ansible` *(fails: tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_689c754d4f108333975cbfd0d6fbe50f