### PR TITLE
Fix include_vars usage for storage config

### DIFF
--- a/dto_proxstor.yml
+++ b/dto_proxstor.yml
@@ -4,9 +4,8 @@
   gather_facts: true
   tasks:
     - name: "01 Load storage configuration"
-      ansible.builtin.include_vars:
-        name: proxstor
-        content: "{{ lookup('template', 'templates/proxstor/' + inventory_hostname + '.yml.j2') }}"
+      ansible.builtin.set_fact:
+        proxstor: "{{ lookup('template', 'templates/proxstor/' + inventory_hostname + '.yml.j2') | from_yaml }}"
 
     - name: "02 Find first free block device"
       ansible.builtin.shell:


### PR DESCRIPTION
## Summary
- use `set_fact` with templated YAML to load proxstor configuration

## Testing
- `ansible-playbook dto_proxstor.yml --syntax-check` *(fails: command not found)*
- `pip install ansible-core` *(fails: Could not find a version that satisfies the requirement ansible-core)*

------
https://chatgpt.com/codex/tasks/task_e_689c85ed1dac833390440c7c24ec54a2