### PR TITLE
Filter free device search to physical disks

### DIFF
--- a/dto_proxstor.yml
+++ b/dto_proxstor.yml
@@ -12,6 +12,7 @@
         free_device: >-
           {{ ansible_devices
              | dict2items
+             | selectattr('key', 'match', '^(sd|hd|vd|xvd|nvme)')
              | selectattr('value.partitions', 'equalto', {})
              | map(attribute='key')
              | sort


### PR DESCRIPTION
## Summary
- ensure free device detection ignores non-disk device-mapper nodes to pick proper disks for storage setup

## Testing
- `ansible-playbook dto_proxstor.yml -i inventory --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c8c34e6d08333bacf1840534577c5