### PR TITLE
Add Proxmox storage cleanup and idempotent provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ target system and its display manager before applying changes.
 
 ## Usage
 
-The inventory `inventory/hosts.ini` contains the Debian host `192.168.188.121` and the Proxmox host `192.168.188.150`. Both use the user `root` for the connection.
+The inventory `inventory/hosts.ini` contains the Debian host `192.168.188.121` and the Proxmox host `192.168.188.150`. Both use
+the user `root` for the connection.
 
 The playbook `dto_user.yml` ensures that the user `ironscope` exists, creates a home directory,
 adds the user to the appropriate admin group for the detected distribution and forces a
@@ -20,7 +21,9 @@ username and current directory in different colors.
 
 The playbook `dto_proxmox.yml` disables the subscription warning on a Proxmox host by patching `/usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js` and restarting the `pveproxy` service. It further displays storage status, network configuration, IP addresses, block devices and the Proxmox version.
 
-The playbook `dto_proxstor.yml` prepares additional LVM storage on a Proxmox host. It locates the first unused block device, creates a volume group and a thin pool that spans the entire device and provisions several thin volumes. Parameters such as the volume group name, thin pool and thin volume sizes are defined in host-specific Jinja files under `templates/proxstor` and can be adjusted per target host. After execution the playbook prints a summary of the available Proxmox storages.
+The playbook `dto_proxstor.yml` prepares additional LVM storage on a Proxmox host. It locates the first unused block device, creates a volume group and a thin pool that spans the entire device and provisions several thin volumes. Parameters such as the volume group name, thin pool and thin volume sizes are defined in host-specific Jinja files under `templates/proxstor` and can be adjusted per target host. After execution the playbook prints a summary of the available Proxmox storages. Running the playbook again will recognise an existing volume group and simply report the current status without failing.
+
+The complementary playbook `dto_proxdestroystor.yml` removes the thin volumes, the thin pool and the volume group again, undoing the changes made by `dto_proxstor.yml`.
 
 Run the playbook:
 
@@ -28,6 +31,7 @@ Run the playbook:
 ansible-playbook -i inventory/hosts.ini dto_user.yml
 ansible-playbook -i inventory/hosts.ini dto_proxmox.yml
 ansible-playbook -i inventory/hosts.ini dto_proxstor.yml
+ansible-playbook -i inventory/hosts.ini dto_proxdestroystor.yml
 ```
 
 ## Versioning

--- a/dto_proxdestroystor.yml
+++ b/dto_proxdestroystor.yml
@@ -1,0 +1,44 @@
+---
+- name: Destroy Proxmox storage
+  hosts: proxmox
+  gather_facts: true
+  tasks:
+    - name: "01 Load storage configuration"
+      ansible.builtin.set_fact:
+        proxstor: "{{ lookup('template', 'templates/proxstor/' + inventory_hostname + '.yml.j2') | from_yaml }}"
+
+    - name: "02 Remove thin volumes"
+      ansible.builtin.lvol:
+        vg: "{{ proxstor.vg_name }}"
+        lv: "{{ item }}"
+        state: absent
+      loop: "{{ proxstor.thin_volumes }}"
+
+    - name: "03 Remove thin pool"
+      ansible.builtin.lvol:
+        vg: "{{ proxstor.vg_name }}"
+        thinpool: "{{ proxstor.thinpool_name }}"
+        state: absent
+
+    - name: "04 Remove volume group"
+      ansible.builtin.lvg:
+        vg: "{{ proxstor.vg_name }}"
+        state: absent
+
+    - name: "05 List logical volumes"
+      ansible.builtin.command: lvs --units g
+      register: lvs_output
+      changed_when: false
+
+    - name: "06 Show logical volumes"
+      ansible.builtin.debug:
+        var: lvs_output.stdout_lines
+
+    - name: "07 List storages"
+      ansible.builtin.command: pvesm status
+      register: storage_status
+      changed_when: false
+
+    - name: "08 Show storages"
+      ansible.builtin.debug:
+        var: storage_status.stdout_lines

--- a/dto_proxstor.yml
+++ b/dto_proxstor.yml
@@ -7,7 +7,13 @@
       ansible.builtin.set_fact:
         proxstor: "{{ lookup('template', 'templates/proxstor/' + inventory_hostname + '.yml.j2') | from_yaml }}"
 
-    - name: "02 Find first free block device"
+    - name: "02 Check for existing volume group"
+      ansible.builtin.command: "vgs {{ proxstor.vg_name }}"
+      register: vg_check
+      failed_when: false
+      changed_when: false
+
+    - name: "03 Find first free block device"
       ansible.builtin.set_fact:
         free_device: >-
           {{ ansible_devices
@@ -18,47 +24,52 @@
              | sort
              | map('regex_replace', '^', '/dev/')
              | first | default('') }}
+      when: vg_check.rc != 0
       changed_when: false
 
-    - name: "03 Assert free block device exists"
+    - name: "04 Assert free block device exists"
       ansible.builtin.assert:
         that:
           - free_device | length > 0
         fail_msg: "No unused block device found."
+      when: vg_check.rc != 0
 
-    - name: "04 Create volume group"
+    - name: "05 Create volume group"
       ansible.builtin.lvg:
         vg: "{{ proxstor.vg_name }}"
         pvs: "{{ free_device }}"
+      when: vg_check.rc != 0
 
-    - name: "05 Create thin pool"
+    - name: "06 Create thin pool"
       ansible.builtin.lvol:
         vg: "{{ proxstor.vg_name }}"
         thinpool: "{{ proxstor.thinpool_name }}"
         size: 100%FREE
+      when: vg_check.rc != 0
 
-    - name: "06 Create thin volumes"
+    - name: "07 Create thin volumes"
       ansible.builtin.lvol:
         vg: "{{ proxstor.vg_name }}"
         thinpool: "{{ proxstor.thinpool_name }}"
         lv: "{{ item }}"
         size: "{{ proxstor.thin_volume_size }}"
       loop: "{{ proxstor.thin_volumes }}"
+      when: vg_check.rc != 0
 
-    - name: "07 List logical volumes"
+    - name: "08 List logical volumes"
       ansible.builtin.command: lvs --units g
       register: lvs_output
       changed_when: false
 
-    - name: "08 Show logical volumes"
+    - name: "09 Show logical volumes"
       ansible.builtin.debug:
         var: lvs_output.stdout_lines
 
-    - name: "09 List storages"
+    - name: "10 List storages"
       ansible.builtin.command: pvesm status
       register: storage_status
       changed_when: false
 
-    - name: "10 Show storages"
+    - name: "11 Show storages"
       ansible.builtin.debug:
         var: storage_status.stdout_lines

--- a/templates/bashrc.j2
+++ b/templates/bashrc.j2
@@ -13,3 +13,4 @@ PS1='\[\e[36m\]$(hostname -I | cut -d" " -f1)\[\e[0m\] \[\e[32m\]\u\[\e[0m\] \[\
 alias admin='ANSIBLE_FORCE_COLOR=true ANSIBLE_STDOUT_CALLBACK=yaml ANSIBLE_CALLBACKS_ENABLED=profile_tasks ansible-playbook -i inventory/hosts.ini dto_user.yml'
 alias prox='ANSIBLE_FORCE_COLOR=true ANSIBLE_STDOUT_CALLBACK=yaml ANSIBLE_CALLBACKS_ENABLED=profile_tasks ansible-playbook -i inventory/hosts.ini dto_proxmox.yml'
 alias proxstor='ANSIBLE_FORCE_COLOR=true ANSIBLE_STDOUT_CALLBACK=yaml ANSIBLE_CALLBACKS_ENABLED=profile_tasks ansible-playbook -i inventory/hosts.ini dto_proxstor.yml'
+alias proxdestroystor='ANSIBLE_FORCE_COLOR=true ANSIBLE_STDOUT_CALLBACK=yaml ANSIBLE_CALLBACKS_ENABLED=profile_tasks ansible-playbook -i inventory/hosts.ini dto_proxdestroystor.yml'


### PR DESCRIPTION
## Summary
- make `dto_proxstor.yml` idempotent by skipping creation when volume group exists
- add `dto_proxdestroystor.yml` to remove thin volumes, pool and volume group
- expose new `proxdestroystor` alias in `bashrc.j2`
- document storage provisioning and cleanup in README

## Testing
- `ansible-playbook --syntax-check dto_proxstor.yml` (fails: command not found)
- `ansible-playbook --syntax-check dto_proxdestroystor.yml` (fails: command not found)
- `apt-get update` (fails: repository not signed)
- `pip install ansible` (fails: tunnel connection failed: 403)


------
https://chatgpt.com/codex/tasks/task_e_689c8e44d5208333bdea93d10ed33df1