### PR TITLE
Configure root prompt for Proxmox hosts

### DIFF
--- a/dto_proxmox.yml
+++ b/dto_proxmox.yml
@@ -77,3 +77,17 @@
     - name: "14 Show block devices"
       ansible.builtin.debug:
         var: block_devices.stdout_lines
+
+    - name: "15 Check if root bashrc exists"
+      ansible.builtin.stat:
+        path: /root/.bashrc
+      register: root_bashrc
+
+    - name: "16 Deploy colorful bashrc for root user"
+      ansible.builtin.template:
+        src: templates/bashrc.j2
+        dest: /root/.bashrc
+        owner: root
+        group: root
+        mode: '0644'
+      when: not root_bashrc.stat.exists

--- a/templates/bashrc.j2
+++ b/templates/bashrc.j2
@@ -1,4 +1,4 @@
-# .bashrc for ironscope user (Ansible managed)
+# .bashrc with colorful prompt (Ansible managed)
 # If not running interactively, exit
 case $- in
     *i*) ;;


### PR DESCRIPTION
## Summary
- deploy colorful bashrc for root in `dto_proxmox.yml`
- generalize bashrc template comment

## Testing
- `ansible-playbook -i inventory/hosts.ini dto_proxmox.yml --syntax-check` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_689c8ea302fc8333828091df3e352184