### PR TITLE
Configure root prompt for Proxmox hosts

### DIFF
--- a/dto_proxmox.yml
+++ b/dto_proxmox.yml
@@ -77,3 +77,12 @@
     - name: "14 Show block devices"
       ansible.builtin.debug:
         var: block_devices.stdout_lines
+
+    - name: "15 Deploy colorful bashrc for root user"
+      ansible.builtin.template:
+        src: templates/bashrc.j2
+        dest: /root/.bashrc
+        owner: root
+        group: root
+        mode: '0644'
+        backup: true

--- a/templates/bashrc.j2
+++ b/templates/bashrc.j2
@@ -1,4 +1,4 @@
-# .bashrc for ironscope user (Ansible managed)
+# .bashrc with colorful prompt (Ansible managed)
 # If not running interactively, exit
 case $- in
     *i*) ;;


### PR DESCRIPTION
## Summary
- deploy colorful bashrc for root in `dto_proxmox.yml`
- generalize bashrc template comment

## Testing
- `apt-get update` *(fails: repository 403 errors)*
- `apt-get install -y ansible` *(fails: package not found)*
- `ansible-playbook -i inventory/hosts.ini dto_proxmox.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c8ea302fc8333828091df3e352184