### PR TITLE
Install root bashrc with colourful prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ package `rclone`, creates the directory `onedrive` in the home directory and set
 as the default shell. Finally, it installs a colorful prompt that displays IP address,
 username and current directory in different colors.
 
-The playbook `dto_proxmox.yml` disables the subscription warning on a Proxmox host by patching `/usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js` and restarting the `pveproxy` service. It further displays storage status, network configuration, IP addresses, block devices and the Proxmox version.
+The playbook `dto_proxmox.yml` disables the subscription warning on a Proxmox host by patching `/usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js` and restarting the `pveproxy` service. It further displays storage status, network configuration, IP addresses, block devices and the Proxmox version and installs a colourful prompt for the root user.
 
 The playbook `dto_proxstor.yml` prepares additional LVM storage on a Proxmox host. It locates the first unused block device, creates a volume group and a thin pool that spans the entire device and provisions several thin volumes. Parameters such as the volume group name, thin pool and thin volume sizes are defined in host-specific Jinja files under `templates/proxstor` and can be adjusted per target host. After execution the playbook prints a summary of the available Proxmox storages. Running the playbook again will recognise an existing volume group and simply report the current status without failing.
 

--- a/dto_proxmox.yml
+++ b/dto_proxmox.yml
@@ -78,12 +78,7 @@
       ansible.builtin.debug:
         var: block_devices.stdout_lines
 
-    - name: "15 Check if root bashrc exists"
-      ansible.builtin.stat:
-        path: /root/.bashrc
-      register: root_bashrc
-
-    - name: "16 Deploy colorful bashrc for root user"
+    - name: "15 Deploy colorful bashrc for root user"
       ansible.builtin.template:
         src: templates/bashrc.j2
         dest: /root/.bashrc
@@ -91,5 +86,4 @@
         group: root
         mode: '0644'
         backup: true
-      when: not root_bashrc.stat.exists
 


### PR DESCRIPTION
## Summary
- Always deploy colourful bashrc for root in Proxmox playbook
- Document root prompt deployment in README

## Testing
- `ansible-playbook -i inventory/hosts.ini --syntax-check dto_proxmox.yml` *(fails: command not found)*
- `apt-get install -y ansible` *(fails: Unable to locate package ansible)*


------
https://chatgpt.com/codex/tasks/task_e_689c97770eb48333837efd27058f105c