### PR TITLE
Add force option to destroy storage and document Ansible aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,20 @@ The playbook also writes a matching entry to `/etc/pve/storage.cfg` and restarts
 
 The complementary playbook `dto_proxdestroystor.yml` removes the storage entry, the thin volumes, the thin pool and the volume group again, undoing the changes made by `dto_proxstor.yml`.
 
-Run the playbook:
+Run the playbooks either directly or via the convenience aliases defined in `.bashrc`:
 
 ```bash
-ansible-playbook -i inventory/hosts.ini dto_user.yml
-ansible-playbook -i inventory/hosts.ini dto_proxmox.yml
-ansible-playbook -i inventory/hosts.ini dto_proxstor.yml
-ansible-playbook -i inventory/hosts.ini dto_proxdestroystor.yml
+# direct commands
+ansible-playbook -i inventory/hosts.ini dto_user.yml          # alias: admin
+ansible-playbook -i inventory/hosts.ini dto_proxmox.yml       # alias: prox
+ansible-playbook -i inventory/hosts.ini dto_proxstor.yml      # alias: proxstor
+ansible-playbook -i inventory/hosts.ini dto_proxdestroystor.yml  # alias: proxdestroystor
+
+# using aliases
+admin
+prox
+proxstor
+proxdestroystor
 ```
 
 ## Versioning

--- a/dto_proxdestroystor.yml
+++ b/dto_proxdestroystor.yml
@@ -26,6 +26,7 @@
         vg: "{{ proxstor.vg_name }}"
         lv: "{{ item }}"
         state: absent
+        force: true
       loop: "{{ proxstor.thin_volumes }}"
 
     - name: "04 Remove thin pool"
@@ -33,11 +34,13 @@
         vg: "{{ proxstor.vg_name }}"
         thinpool: "{{ proxstor.thinpool_name }}"
         state: absent
+        force: true
 
     - name: "05 Remove volume group"
       ansible.builtin.lvg:
         vg: "{{ proxstor.vg_name }}"
         state: absent
+        force: true
 
     - name: "06 List logical volumes"
       ansible.builtin.command: lvs --units g


### PR DESCRIPTION
## Summary
- allow forceful removal of Proxmox thin volumes, thin pool, and volume group
- document `.bashrc` aliases for running playbooks

## Testing
- `ansible-playbook --version` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c9cead83483339b846c3c82777102