### PR TITLE
Add PDF summary generation to proxstat

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ username and current directory in different colors.
 ### Proxmox playbooks
 
 The playbook `dto_proxstat.yml` displays storage status, network configuration, IP addresses,
-block devices and the Proxmox version.
+block devices and the Proxmox version. It also generates `proxmox-summary.pdf` which summarises
+this information for each queried server on its own page.
 
 The playbook `dto_proxcomfort.yml` disables the subscription warning on a Proxmox host by
 patching `/usr/share/javascript/proxmox-widget-toolkit/proxmoxlib.js` and restarting the

--- a/dto_proxstat.yml
+++ b/dto_proxstat.yml
@@ -48,3 +48,30 @@
     - name: "10 Show block devices"
       ansible.builtin.debug:
         var: block_devices.stdout_lines
+
+
+    - name: "11 Collect data for summary"
+      ansible.builtin.set_fact:
+        proxstat_data:
+          storage_status: "{{ storage_status.stdout_lines }}"
+          network_config: "{{ network_config.stdout | from_json }}"
+          ip_addresses: "{{ ip_addr_output.stdout_lines }}"
+          pve_version: "{{ pve_version.stdout_lines }}"
+          block_devices: "{{ block_devices.stdout_lines }}"
+
+- name: Build Proxmox summary PDF
+  hosts: localhost
+  gather_facts: false
+  vars:
+    summary_markdown: proxmox-summary.md
+  tasks:
+    - name: Render Proxmox summary markdown
+      ansible.builtin.template:
+        src: templates/proxmox_summary.md.j2
+        dest: "{{ summary_markdown }}"
+
+    - name: Create Proxmox summary PDF
+      ansible.builtin.command:
+        cmd: pandoc {{ summary_markdown }} -o proxmox-summary.pdf
+      args:
+        creates: proxmox-summary.pdf

--- a/templates/proxmox_summary.md.j2
+++ b/templates/proxmox_summary.md.j2
@@ -1,0 +1,21 @@
+{% for host in groups['proxmox'] %}
+# {{ hostvars[host].ansible_host | default(host) }} - {{ hostvars[host].ansible_hostname }}
+
+## Storage
+{{ hostvars[host].proxstat_data.storage_status | join('\n') }}
+
+## Network
+{{ hostvars[host].proxstat_data.network_config | to_nice_yaml }}
+
+## IP addresses
+{{ hostvars[host].proxstat_data.ip_addresses | join('\n') }}
+
+## Proxmox version
+{{ hostvars[host].proxstat_data.pve_version | join('\n') }}
+
+## Block devices
+{{ hostvars[host].proxstat_data.block_devices | join('\n') }}
+{% if not loop.last %}
+\\newpage
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
## Summary
- Generate per-host Proxmox summaries and compile them into proxmox-summary.pdf
- Add Jinja2 template for PDF rendering with page-per-host layout
- Document new PDF output in README

## Testing
- `ansible-playbook --syntax-check dto_proxstat.yml` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d7283046483338750ba0517b9483b