### PR TITLE
fix proxstat template generation

### DIFF
--- a/dto_proxstat.yml
+++ b/dto_proxstat.yml
@@ -60,11 +60,9 @@
           block_devices: "{{ block_devices.stdout_lines }}"
 
     - name: Build Proxmox summary HTML
-      hosts: localhost
-      gather_facts: false
-      tasks:
-        - name: Render Proxmox summary HTML
-          ansible.builtin.template:
-            src: templates/proxmox_summary.html.j2
-            dest: proxmox-summary.html
+      ansible.builtin.template:
+        src: templates/proxmox_summary.html.j2
+        dest: proxmox-summary.html
+      delegate_to: localhost
+      run_once: true
 


### PR DESCRIPTION
## Summary
- fix proxstat playbook by delegating HTML template to localhost

## Testing
- `ansible-playbook dto_proxstat.yml --syntax-check` *(fails: command not found)*
- `pip install ansible` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689d756f00848333bb9c827427e3ab96