### PR TITLE
Extend proxstat summary with system details and VM list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ username and current directory in different colors.
 ### Proxmox playbooks
 
 The playbook `dto_proxstat.yml` displays storage status, network configuration, IP addresses,
-
-block devices and the Proxmox version. It also generates `proxmox-summary.pdf` which summarises
-this information for each queried server on its own page.
+block devices, hardware details, the system uptime and the Proxmox version. It also lists
+virtual machines and generates `proxmox-summary.pdf` which summarises this information for
+each queried server on its own page and includes the report creation date.
 
 
 The playbook `dto_proxcomfort.yml` disables the subscription warning on a Proxmox host by

--- a/dto_proxstat.yml
+++ b/dto_proxstat.yml
@@ -49,8 +49,34 @@
       ansible.builtin.debug:
         var: block_devices.stdout_lines
 
+    - name: "11 Gather hardware details"
+      ansible.builtin.command: lshw -json
+      register: hardware_details
+      changed_when: false
 
-    - name: "11 Collect data for summary"
+    - name: "12 Show hardware details"
+      ansible.builtin.debug:
+        var: hardware_details.stdout
+
+    - name: "13 Get system uptime"
+      ansible.builtin.command: uptime -p
+      register: uptime
+      changed_when: false
+
+    - name: "14 Show system uptime"
+      ansible.builtin.debug:
+        var: uptime.stdout
+
+    - name: "15 List virtual machines"
+      ansible.builtin.command: qm list
+      register: vm_list
+      changed_when: false
+
+    - name: "16 Show virtual machines"
+      ansible.builtin.debug:
+        var: vm_list.stdout_lines
+
+    - name: "17 Collect data for summary"
       ansible.builtin.set_fact:
         proxstat_data:
           storage_status: "{{ storage_status.stdout_lines }}"
@@ -58,6 +84,10 @@
           ip_addresses: "{{ ip_addr_output.stdout_lines }}"
           pve_version: "{{ pve_version.stdout_lines }}"
           block_devices: "{{ block_devices.stdout_lines }}"
+          hardware_details: "{{ hardware_details.stdout }}"
+          uptime: "{{ uptime.stdout }}"
+          creation_date: "{{ ansible_date_time.iso8601 }}"
+          vm_list: "{{ vm_list.stdout_lines }}"
 
     - name: Build Proxmox summary HTML
       ansible.builtin.template:
@@ -65,4 +95,3 @@
         dest: proxmox-summary.html
       delegate_to: localhost
       run_once: true
-

--- a/templates/proxmox_summary.html.j2
+++ b/templates/proxmox_summary.html.j2
@@ -11,9 +11,12 @@
   </style>
 </head>
 <body>
+  <p>Report generated: {{ hostvars[groups['proxmox'][0]].proxstat_data.creation_date }}</p>
 {% for host in groups['proxmox'] %}
   <div class="section">
     <h1>{{ hostvars[host].ansible_host | default(host) }} - {{ hostvars[host].ansible_hostname }}</h1>
+    <p>Proxmox version: {{ hostvars[host].proxstat_data.pve_version | join(', ') }}<br>
+       Uptime: {{ hostvars[host].proxstat_data.uptime }}</p>
 
     <h2>Storage</h2>
     <pre>{{ hostvars[host].proxstat_data.storage_status | join('\n') }}</pre>
@@ -24,11 +27,14 @@
     <h2>IP addresses</h2>
     <pre>{{ hostvars[host].proxstat_data.ip_addresses | join('\n') }}</pre>
 
-    <h2>Proxmox version</h2>
-    <pre>{{ hostvars[host].proxstat_data.pve_version | join('\n') }}</pre>
-
     <h2>Block devices</h2>
     <pre>{{ hostvars[host].proxstat_data.block_devices | join('\n') }}</pre>
+
+    <h2>Hardware details</h2>
+    <pre>{{ hostvars[host].proxstat_data.hardware_details }}</pre>
+
+    <h2>Virtual machines</h2>
+    <pre>{{ hostvars[host].proxstat_data.vm_list | join('\n') }}</pre>
   </div>
 {% endfor %}
 </body>

--- a/templates/proxmox_summary.md.j2
+++ b/templates/proxmox_summary.md.j2
@@ -1,20 +1,27 @@
+Report generated: {{ hostvars[groups['proxmox'][0]].proxstat_data.creation_date }}
+
 {% for host in groups['proxmox'] %}
 # {{ hostvars[host].ansible_host | default(host) }} - {{ hostvars[host].ansible_hostname }}
+Proxmox version: {{ hostvars[host].proxstat_data.pve_version | join(', ') }}
+Uptime: {{ hostvars[host].proxstat_data.uptime }}
 
 ## Storage
-{{ hostvars[host].proxstat_data.storage_status | join('\n') }}
+{{ hostvars[host].proxstat_data.storage_status | join('\\n') }}
 
 ## Network
 {{ hostvars[host].proxstat_data.network_config | to_nice_yaml }}
 
 ## IP addresses
-{{ hostvars[host].proxstat_data.ip_addresses | join('\n') }}
-
-## Proxmox version
-{{ hostvars[host].proxstat_data.pve_version | join('\n') }}
+{{ hostvars[host].proxstat_data.ip_addresses | join('\\n') }}
 
 ## Block devices
-{{ hostvars[host].proxstat_data.block_devices | join('\n') }}
+{{ hostvars[host].proxstat_data.block_devices | join('\\n') }}
+
+## Hardware details
+{{ hostvars[host].proxstat_data.hardware_details }}
+
+## Virtual machines
+{{ hostvars[host].proxstat_data.vm_list | join('\\n') }}
 {% if not loop.last %}
 \\newpage
 {% endif %}


### PR DESCRIPTION
## Summary
- collect hardware info, uptime, and VM list in `dto_proxstat.yml`
- show report creation date, Proxmox version, uptime, hardware details, and virtual machines in HTML/Markdown summaries
- document new proxstat features in README

## Testing
- `ansible-playbook -i inventory/hosts.ini dto_proxstat.yml --syntax-check` *(fails: command not found)*
- `apt-get update` *(fails: repository access errors)*

------
https://chatgpt.com/codex/tasks/task_e_689d79828fd083338c2e328a10044061