### PR TITLE
Fix Proxmox status playbook syntax

### DIFF
--- a/dto_proxstat.yml
+++ b/dto_proxstat.yml
@@ -84,36 +84,6 @@
         var: vm_list.stdout_lines
 
     - name: "18 Collect data for summary"
-
-    - name: "11 Gather hardware details"
-      ansible.builtin.command: lshw -json
-      register: hardware_details
-      changed_when: false
-
-    - name: "12 Show hardware details"
-      ansible.builtin.debug:
-        var: hardware_details.stdout
-
-    - name: "13 Get system uptime"
-      ansible.builtin.command: uptime -p
-      register: uptime
-      changed_when: false
-
-    - name: "14 Show system uptime"
-      ansible.builtin.debug:
-        var: uptime.stdout
-
-    - name: "15 List virtual machines"
-      ansible.builtin.command: qm list
-      register: vm_list
-      changed_when: false
-
-    - name: "16 Show virtual machines"
-      ansible.builtin.debug:
-        var: vm_list.stdout_lines
-
-    - name: "17 Collect data for summary"
-
       ansible.builtin.set_fact:
         proxstat_data:
           storage_status: "{{ storage_status.stdout_lines }}"


### PR DESCRIPTION
## Summary
- remove duplicated tasks and correctly collect summary data in Proxmox status playbook

## Testing
- ⚠️ `ansible-playbook -i inventory --syntax-check dto_proxstat.yml` (command not found; attempted `apt-get update` and `pip install ansible` but both failed due to 403 proxy restrictions)


------
https://chatgpt.com/codex/tasks/task_e_689d7e8a11348333848065468b867797