### PR TITLE
Handle limited hosts in Proxmox reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ansible_cache/

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+fact_caching = jsonfile
+fact_caching_connection = .ansible_cache
+fact_caching_timeout = 86400

--- a/dto_proxstat.yml
+++ b/dto_proxstat.yml
@@ -95,6 +95,7 @@
           uptime: "{{ uptime.stdout }}"
           creation_date: "{{ ansible_date_time.iso8601 }}"
           vm_list: "{{ vm_list.stdout_lines }}"
+      cacheable: true
 
     - name: Build Proxmox summary HTML
       ansible.builtin.template:

--- a/templates/proxmox_summary.html.j2
+++ b/templates/proxmox_summary.html.j2
@@ -11,8 +11,9 @@
   </style>
 </head>
 <body>
-  <p>Report generated: {{ hostvars[groups['proxmox'][0]].proxstat_data.creation_date }}</p>
-{% for host in groups['proxmox'] %}
+  <p>Report generated: {{ hostvars[ansible_play_hosts[0]].proxstat_data.creation_date | default('N/A') }}</p>
+{% for host in ansible_play_hosts %}
+  {% if hostvars[host].proxstat_data is defined %}
   <div class="section">
     <h1>{{ hostvars[host].ansible_host | default(host) }} - {{ hostvars[host].ansible_hostname }}</h1>
     <p>Proxmox version: {{ hostvars[host].proxstat_data.pve_version | join(', ') }}<br>
@@ -36,6 +37,7 @@
     <h2>Virtual machines</h2>
     <pre>{{ hostvars[host].proxstat_data.vm_list | join('\n') }}</pre>
   </div>
+  {% endif %}
 {% endfor %}
 </body>
 </html>

--- a/templates/proxmox_summary.md.j2
+++ b/templates/proxmox_summary.md.j2
@@ -1,6 +1,7 @@
-Report generated: {{ hostvars[groups['proxmox'][0]].proxstat_data.creation_date }}
+Report generated: {{ hostvars[ansible_play_hosts[0]].proxstat_data.creation_date | default('N/A') }}
 
-{% for host in groups['proxmox'] %}
+{% for host in ansible_play_hosts %}
+{% if hostvars[host].proxstat_data is defined %}
 # {{ hostvars[host].ansible_host | default(host) }} - {{ hostvars[host].ansible_hostname }}
 Proxmox version: {{ hostvars[host].proxstat_data.pve_version | join(', ') }}
 Uptime: {{ hostvars[host].proxstat_data.uptime }}
@@ -24,5 +25,6 @@ Uptime: {{ hostvars[host].proxstat_data.uptime }}
 {{ hostvars[host].proxstat_data.vm_list | join('\\n') }}
 {% if not loop.last %}
 \\newpage
+{% endif %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
## Summary
- Cache Proxmox statistics for later report generation
- Render reports only for hosts targeted in the play
- Configure Ansible fact caching via ansible.cfg

## Testing
- ❌ `ansible-playbook --syntax-check dto_proxstat.yml` *(command not found)*
- ⚠️ `apt-get update` *(403 Forbidden from package repositories)*

------
https://chatgpt.com/codex/tasks/task_e_689d85a1b7bc8333a31e0335c683aa0e