### PR TITLE
fix: correct set_fact cacheable syntax

### DIFF
--- a/dto_proxstat.yml
+++ b/dto_proxstat.yml
@@ -95,7 +95,7 @@
           uptime: "{{ uptime.stdout }}"
           creation_date: "{{ ansible_date_time.iso8601 }}"
           vm_list: "{{ vm_list.stdout_lines }}"
-      cacheable: true
+        cacheable: true
 
     - name: Build Proxmox summary HTML
       ansible.builtin.template:


### PR DESCRIPTION
## Summary
- fix cacheable indentation in dto_proxstat.yml

## Testing
- `ansible-playbook --syntax-check -i inventory/hosts.ini dto_proxstat.yml` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689d8d570b148333b9f6ee45905f4b3c