### PR TITLE
Restart Proxmox storage monitoring after storage changes

### DIFF
--- a/dto_proxstorage.yml
+++ b/dto_proxstorage.yml
@@ -56,35 +56,38 @@
       loop: "{{ proxstorage.thin_volumes }}"
       when: vg_check.rc != 0
 
-    - name: "08 Configure Proxmox storage"
-      ansible.builtin.blockinfile:
-        path: /etc/pve/storage.cfg
-        marker: "# {mark} ANSIBLE MANAGED proxstorage"
-        block: |
-          lvmthin: {{ proxstorage.storage_name }}
-              thinpool {{ proxstorage.thinpool_name }}
-              vgname {{ proxstorage.vg_name }}
-              content rootdir,images
-        create: true
+    - name: "08 Check for existing storage definition"
+      ansible.builtin.command: pvesm status
+      register: pvesm_status
+      changed_when: false
+
+    - name: "09 Configure Proxmox storage"
+      ansible.builtin.command: >-
+        pvesm add lvmthin {{ proxstorage.storage_name }}
+        -vgname {{ proxstorage.vg_name }}
+        -thinpool {{ proxstorage.thinpool_name }}
+        -content rootdir,images
+      when: proxstorage.storage_name not in pvesm_status.stdout
       notify:
         - Restart pvedaemon
         - Restart pveproxy
+        - Restart pvestatd
 
-    - name: "09 List logical volumes"
+    - name: "10 List logical volumes"
       ansible.builtin.command: lvs --units g
       register: lvs_output
       changed_when: false
 
-    - name: "10 Show logical volumes"
+    - name: "11 Show logical volumes"
       ansible.builtin.debug:
         var: lvs_output.stdout_lines
 
-    - name: "11 List storages"
+    - name: "12 List storages"
       ansible.builtin.command: pvesm status
       register: storage_status
       changed_when: false
 
-    - name: "12 Show storages"
+    - name: "13 Show storages"
       ansible.builtin.debug:
         var: storage_status.stdout_lines
 
@@ -97,4 +100,9 @@
     - name: Restart pveproxy
       ansible.builtin.service:
         name: pveproxy
+        state: restarted
+
+    - name: Restart pvestatd
+      ansible.builtin.service:
+        name: pvestatd
         state: restarted

--- a/dto_proxstoragedestroy.yml
+++ b/dto_proxstoragedestroy.yml
@@ -8,18 +8,14 @@
         proxstorage: "{{ lookup('template', 'templates/proxstorage/' + inventory_hostname + '.yml.j2') | from_yaml }}"
 
     - name: "02 Remove Proxmox storage configuration"
-      ansible.builtin.blockinfile:
-        path: /etc/pve/storage.cfg
-        marker: "# {mark} ANSIBLE MANAGED proxstorage"
-        block: |
-          lvmthin: {{ proxstorage.storage_name }}
-              thinpool {{ proxstorage.thinpool_name }}
-              vgname {{ proxstorage.vg_name }}
-              content rootdir,images
-        state: absent
+      ansible.builtin.command: "pvesm remove {{ proxstorage.storage_name }}"
+      register: remove_storage
+      failed_when: false
+      changed_when: remove_storage.rc == 0
       notify:
         - Restart pvedaemon
         - Restart pveproxy
+        - Restart pvestatd
 
     - name: "03 Remove thin volumes"
       ansible.builtin.lvol:
@@ -69,4 +65,9 @@
     - name: Restart pveproxy
       ansible.builtin.service:
         name: pveproxy
+        state: restarted
+
+    - name: Restart pvestatd
+      ansible.builtin.service:
+        name: pvestatd
         state: restarted


### PR DESCRIPTION
## Summary
- add pvesm-based storage creation to update `/etc/pve/storage.cfg`
- remove storage definitions with `pvesm remove` when tearing down volumes

## Testing
- `ansible-playbook --syntax-check dto_proxstorage.yml` *(command not found)*
- `apt-get update` *(403  Forbidden repository; not signed)*
- `pip install ansible` *(proxy 403; no matching distribution found)*
- `ansible-playbook --syntax-check dto_proxstoragedestroy.yml` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d93729de083339122e0b68e5cc971