### PR TITLE
Add proxinvoke and proxrevoke playbooks for VM lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ The complementary playbook `dto_proxstoragedestroy.yml` removes the storage entr
 volumes, the thin pool and the volume group again, undoing the changes made by
 `dto_proxstorage.yml`.
 
+The playbook `dto_proxinvoke.yml` provisioniert eine neue virtuelle Maschine auf
+einem Proxmox-Host. Es lädt alle relevanten Parameter – Name, Zielhost,
+Festplattengröße, CPU-, Speicher- und Netzwerkkonfiguration – aus
+host­spezifischen Jinja-Dateien unter `templates/proxinvoke`. Vor der
+Erstellung wird geprüft, ob der Zielhost sowie das angegebene Storage vorhanden
+sind. Existiert die Maschine noch nicht, wird sie erzeugt und gestartet.
+
+Das Gegenstück `dto_proxrevoke.yml` entfernt eine zuvor angelegte VM einschließlich
+der zugehörigen Laufwerke wieder vom Zielhost.
+
 Run the playbooks either directly or via the convenience aliases defined in `.bashrc`:
 
 ```bash
@@ -63,6 +73,8 @@ ansible-playbook -i inventory/hosts.ini dto_proxreport.yml      # alias: proxrep
 ansible-playbook -i inventory/hosts.ini dto_proxcomfort.yml     # alias: proxcomfort
 ansible-playbook -i inventory/hosts.ini dto_proxstorage.yml     # alias: proxstorage
 ansible-playbook -i inventory/hosts.ini dto_proxstoragedestroy.yml # alias: proxstoragedestroy
+ansible-playbook -i inventory/hosts.ini dto_proxinvoke.yml     # alias: proxinvoke
+ansible-playbook -i inventory/hosts.ini dto_proxrevoke.yml     # alias: proxrevoke
 
 # using aliases
 admin
@@ -70,6 +82,8 @@ proxreport
 proxcomfort
 proxstorage
 proxstoragedestroy
+proxinvoke
+proxrevoke
 ```
 
 ## Versioning

--- a/dto_proxinvoke.yml
+++ b/dto_proxinvoke.yml
@@ -1,0 +1,74 @@
+---
+- name: Create Proxmox virtual machines
+  hosts: proxmox
+  gather_facts: true
+  tasks:
+    - name: "01 Verify host availability"
+      ansible.builtin.ping:
+
+    - name: "02 Check for host configuration"
+      ansible.builtin.stat:
+        path: "templates/proxinvoke/{{ inventory_hostname }}.yml.j2"
+      register: proxinvoke_template
+
+    - name: "02a Skip host without configuration"
+      ansible.builtin.debug:
+        msg: "Keine Konfiguration für {{ inventory_hostname }} vorhanden – Host wird übersprungen."
+      when: not proxinvoke_template.stat.exists
+
+    - meta: end_host
+      when: not proxinvoke_template.stat.exists
+
+    - name: "03 Load VM configuration"
+      ansible.builtin.set_fact:
+        proxinvoke: "{{ lookup('template', 'templates/proxinvoke/' + inventory_hostname + '.yml.j2') | from_yaml }}"
+
+    - name: "04 Ensure configuration targets this host"
+      ansible.builtin.assert:
+        that:
+          - proxinvoke.target_host == inventory_hostname
+        fail_msg: "Konfiguration zielt auf einen anderen Host."
+
+    - name: "05 Check for required storage"
+      ansible.builtin.command: pvesm status
+      register: storage_status
+      changed_when: false
+
+    - name: "06 Assert storage present"
+      ansible.builtin.assert:
+        that:
+          - proxinvoke.storage in storage_status.stdout
+        fail_msg: "Benötigtes Storage {{ proxinvoke.storage }} nicht vorhanden."
+
+    - name: "07 Check if VM already exists"
+      ansible.builtin.command: qm list
+      register: qm_list
+      changed_when: false
+
+    - name: "08 Create VM"
+      ansible.builtin.command: >-
+        qm create {{ proxinvoke.vmid }}
+        --name {{ proxinvoke.name }}
+        --memory {{ proxinvoke.memory }}
+        --cores {{ proxinvoke.cores }}
+        --net0 {{ proxinvoke.networks[0] }}
+      when: proxinvoke.vmid|string not in qm_list.stdout
+
+    - name: "09 Configure disk"
+      ansible.builtin.command: >-
+        qm set {{ proxinvoke.vmid }}
+        --scsi0 {{ proxinvoke.storage }}:{{ proxinvoke.disk_size }},discard=on
+      when: proxinvoke.vmid|string not in qm_list.stdout
+
+    - name: "10 Start VM"
+      ansible.builtin.command: "qm start {{ proxinvoke.vmid }}"
+      when: proxinvoke.vmid|string not in qm_list.stdout
+
+    - name: "11 Show VM status"
+      ansible.builtin.command: "qm status {{ proxinvoke.vmid }}"
+      register: vm_status
+      changed_when: false
+
+    - name: "12 Display VM status"
+      ansible.builtin.debug:
+        var: vm_status.stdout_lines

--- a/dto_proxrevoke.yml
+++ b/dto_proxrevoke.yml
@@ -1,0 +1,59 @@
+---
+- name: Remove Proxmox virtual machines
+  hosts: proxmox
+  gather_facts: true
+  tasks:
+    - name: "01 Verify host availability"
+      ansible.builtin.ping:
+
+    - name: "02 Check for host configuration"
+      ansible.builtin.stat:
+        path: "templates/proxinvoke/{{ inventory_hostname }}.yml.j2"
+      register: proxrevoke_template
+
+    - name: "02a Skip host without configuration"
+      ansible.builtin.debug:
+        msg: "Keine Konfiguration für {{ inventory_hostname }} vorhanden – Host wird übersprungen."
+      when: not proxrevoke_template.stat.exists
+
+    - meta: end_host
+      when: not proxrevoke_template.stat.exists
+
+    - name: "03 Load VM configuration"
+      ansible.builtin.set_fact:
+        proxrevoke: "{{ lookup('template', 'templates/proxinvoke/' + inventory_hostname + '.yml.j2') | from_yaml }}"
+
+    - name: "04 Ensure configuration targets this host"
+      ansible.builtin.assert:
+        that:
+          - proxrevoke.target_host == inventory_hostname
+        fail_msg: "Konfiguration zielt auf einen anderen Host."
+
+    - name: "05 Check existing VMs"
+      ansible.builtin.command: qm list
+      register: qm_list
+      changed_when: false
+
+    - name: "06 Stop VM if running"
+      ansible.builtin.command: "qm stop {{ proxrevoke.vmid }}"
+      register: stop_result
+      failed_when: stop_result.rc not in [0, 255]
+      when: proxrevoke.vmid|string in qm_list.stdout
+
+    - name: "07 Destroy VM"
+      ansible.builtin.command: "qm destroy {{ proxrevoke.vmid }} --purge 1"
+      when: proxrevoke.vmid|string in qm_list.stdout
+
+    - name: "08 VM not found message"
+      ansible.builtin.debug:
+        msg: "VM {{ proxrevoke.vmid }} existiert nicht."
+      when: proxrevoke.vmid|string not in qm_list.stdout
+
+    - name: "09 Show remaining VMs"
+      ansible.builtin.command: qm list
+      register: qm_list_after
+      changed_when: false
+
+    - name: "10 Display remaining VMs"
+      ansible.builtin.debug:
+        var: qm_list_after.stdout_lines

--- a/templates/bashrc.j2
+++ b/templates/bashrc.j2
@@ -15,3 +15,5 @@ alias proxreport='ANSIBLE_FORCE_COLOR=true ANSIBLE_STDOUT_CALLBACK=yaml ANSIBLE_
 alias proxcomfort='ANSIBLE_FORCE_COLOR=true ANSIBLE_STDOUT_CALLBACK=yaml ANSIBLE_CALLBACKS_ENABLED=profile_tasks ansible-playbook -i inventory/hosts.ini dto_proxcomfort.yml'
 alias proxstorage='ANSIBLE_FORCE_COLOR=true ANSIBLE_STDOUT_CALLBACK=yaml ANSIBLE_CALLBACKS_ENABLED=profile_tasks ansible-playbook -i inventory/hosts.ini dto_proxstorage.yml'
 alias proxstoragedestroy='ANSIBLE_FORCE_COLOR=true ANSIBLE_STDOUT_CALLBACK=yaml ANSIBLE_CALLBACKS_ENABLED=profile_tasks ansible-playbook -i inventory/hosts.ini dto_proxstoragedestroy.yml'
+alias proxinvoke='ANSIBLE_FORCE_COLOR=true ANSIBLE_STDOUT_CALLBACK=yaml ANSIBLE_CALLBACKS_ENABLED=profile_tasks ansible-playbook -i inventory/hosts.ini dto_proxinvoke.yml'
+alias proxrevoke='ANSIBLE_FORCE_COLOR=true ANSIBLE_STDOUT_CALLBACK=yaml ANSIBLE_CALLBACKS_ENABLED=profile_tasks ansible-playbook -i inventory/hosts.ini dto_proxrevoke.yml'

--- a/templates/proxinvoke/192.168.188.101.yml.j2
+++ b/templates/proxinvoke/192.168.188.101.yml.j2
@@ -1,0 +1,30 @@
+# VM-Konfiguration für {{ inventory_hostname }}
+#
+# Diese Jinja2-Vorlage beschreibt alle Parameter, die zum Anlegen einer
+# virtuellen Maschine auf dem Proxmox-Zielsystem benötigt werden. Die Werte
+# können bei Bedarf angepasst oder erweitert werden.
+
+# Eindeutige ID der VM innerhalb des Proxmox-Clusters.
+vmid: 9000
+
+# Anzeigename der zu erstellenden VM.
+name: dto-testvm
+
+# IP-Adresse oder Hostname des Proxmox-Knotens, auf dem die VM erstellt wird.
+target_host: 192.168.188.101
+
+# Name des vorhandenen Proxmox-Storages für die Systemfestplatte.
+storage: dto-lvmthin
+
+# Größe der Systemfestplatte.
+disk_size: 10G
+
+# Anzahl der vCPUs.
+cores: 2
+
+# Arbeitsspeicher der VM in MiB.
+memory: 2048
+
+# Netzwerkdefinitionen. Weitere Einträge können ergänzt werden.
+networks:
+  - virtio,bridge=vmbr0


### PR DESCRIPTION
## Summary
- handle missing host configs in proxinvoke and correct disk creation
- introduce proxrevoke playbook and alias to remove VMs cleanly
- document proxrevoke usage alongside proxinvoke

## Testing
- `pip install ansible` *(fails: Tunnel connection failed: 403 Forbidden)*
- `ansible-playbook --syntax-check dto_proxinvoke.yml` *(fails: command not found)*
- `ansible-playbook --syntax-check dto_proxrevoke.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9a38192483339cf2fd9acee491b2