### PR TITLE
fix proxinvoke template lookup

### DIFF
--- a/dto_proxinvoke.yml
+++ b/dto_proxinvoke.yml
@@ -8,8 +8,9 @@
 
     - name: "02 Check for host configuration"
       ansible.builtin.stat:
-        path: "templates/proxinvoke/{{ inventory_hostname }}.yml.j2"
+        path: "{{ playbook_dir }}/templates/proxinvoke/{{ inventory_hostname }}.yml.j2"
       register: proxinvoke_template
+      delegate_to: localhost
 
     - name: "02a Skip host without configuration"
       ansible.builtin.debug:
@@ -21,7 +22,7 @@
 
     - name: "03 Load VM configuration"
       ansible.builtin.set_fact:
-        proxinvoke: "{{ lookup('template', 'templates/proxinvoke/' + inventory_hostname + '.yml.j2') | from_yaml }}"
+        proxinvoke: "{{ lookup('template', playbook_dir ~ '/templates/proxinvoke/' ~ inventory_hostname ~ '.yml.j2') | from_yaml }}"
 
     - name: "04 Ensure configuration targets this host"
       ansible.builtin.assert:

--- a/dto_proxrevoke.yml
+++ b/dto_proxrevoke.yml
@@ -8,8 +8,9 @@
 
     - name: "02 Check for host configuration"
       ansible.builtin.stat:
-        path: "templates/proxinvoke/{{ inventory_hostname }}.yml.j2"
+        path: "{{ playbook_dir }}/templates/proxinvoke/{{ inventory_hostname }}.yml.j2"
       register: proxrevoke_template
+      delegate_to: localhost
 
     - name: "02a Skip host without configuration"
       ansible.builtin.debug:
@@ -21,7 +22,7 @@
 
     - name: "03 Load VM configuration"
       ansible.builtin.set_fact:
-        proxrevoke: "{{ lookup('template', 'templates/proxinvoke/' + inventory_hostname + '.yml.j2') | from_yaml }}"
+        proxrevoke: "{{ lookup('template', playbook_dir ~ '/templates/proxinvoke/' ~ inventory_hostname ~ '.yml.j2') | from_yaml }}"
 
     - name: "04 Ensure configuration targets this host"
       ansible.builtin.assert:


### PR DESCRIPTION
## Summary
- fix proxinvoke template lookup by performing stat on localhost and referencing playbook_dir
- fix proxrevoke template lookup by performing stat on localhost and referencing playbook_dir

## Testing
- `ansible-playbook dto_proxinvoke.yml --syntax-check -i inventory/hosts.ini` *(fails: command not found)*
- `ansible-playbook dto_proxrevoke.yml --syntax-check -i inventory/hosts.ini` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden from repositories)*
- `apt-get install ansible -y` *(fails: Unable to locate package ansible)*

------
https://chatgpt.com/codex/tasks/task_e_689da017fbd88333ab9c23620047031b