### PR TITLE
Fix disk creation on VM provisioning

### DIFF
--- a/dto_proxinvoke.yml
+++ b/dto_proxinvoke.yml
@@ -58,7 +58,7 @@
     - name: "09 Configure disk"
       ansible.builtin.command: >-
         qm set {{ proxinvoke.vmid }}
-        --scsi0 {{ proxinvoke.storage }}:vm-{{ proxinvoke.vmid }}-disk-0,discard=on,size={{ proxinvoke.disk_size }}
+        --scsi0 {{ proxinvoke.storage }}:{{ proxinvoke.disk_size }},discard=on
       when: proxinvoke.vmid|string not in qm_list.stdout
 
     - name: "10 Start VM"


### PR DESCRIPTION
## Summary
- ensure VM disks are created on the configured Proxmox storage

## Testing
- `ansible-playbook -i inventory/hosts.ini --syntax-check dto_proxinvoke.yml` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689da6fc61908333aa4971ab53100229