### PR TITLE
Add SMBIOS type1 configuration to proxinvoke

### DIFF
--- a/dto_proxinvoke.yml
+++ b/dto_proxinvoke.yml
@@ -53,6 +53,9 @@
         --memory {{ proxinvoke.memory }}
         --cores {{ proxinvoke.cores }}
         --net0 {{ proxinvoke.networks[0] }}
+        {% if proxinvoke.smbios1 is defined %}
+        --smbios1 "uuid={{ proxinvoke.smbios1.uuid }},manufacturer={{ proxinvoke.smbios1.manufacturer }},product={{ proxinvoke.smbios1.product }}"
+        {% endif %}
       when: proxinvoke.vmid|string not in qm_list.stdout
 
     - name: "09 Configure disk"

--- a/templates/proxinvoke/192.168.188.101.yml.j2
+++ b/templates/proxinvoke/192.168.188.101.yml.j2
@@ -28,3 +28,9 @@ memory: 5000
 # Netzwerkdefinitionen. Weitere Einträge können ergänzt werden.
 networks:
   - virtio,bridge=vmbr0
+
+# SMBIOS (type1) configuration for the VM.
+smbios1:
+  uuid: 2c269505-717e-490b-a1cb-a089cc71e9c8
+  manufacturer: "Dell Inc."
+  product: "PowerEdge R730"


### PR DESCRIPTION
## Summary
- define Dell R730 SMBIOS parameters in proxinvoke host template
- include SMBIOS options when creating VMs

## Testing
- `ansible-playbook dto_proxinvoke.yml --syntax-check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dafeb97348333b081efd90e0f5794