### PR TITLE
sanitize disk size for proxinvoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ auch mehrere Proxmox‑Server. Alle Verbindungen erfolgen als Benutzer `root`.
   `dto_proxstoragedestroy.yml` macht diese Änderungen rückgängig.
 - `dto_proxinvoke.yml` erstellt neue virtuelle Maschinen. Alle
   VM‑Einstellungen wie `vmid`, `name`, `target_host`, `storage`,
-  `disk_size` (in GiB), `cores`, `memory` und `networks` stammen aus der
-  Datei `templates/proxinvoke/<inventory_hostname>.yml.j2`.
+  `disk_size` (GiB, optional mit "G"‑Suffix), `cores`, `memory` und `networks`
+  stammen aus der Datei `templates/proxinvoke/<inventory_hostname>.yml.j2`.
   Die gleiche Vorlage nutzt `dto_proxrevoke.yml`, um VMs wieder zu
   entfernen.
 

--- a/dto_proxinvoke.yml
+++ b/dto_proxinvoke.yml
@@ -61,7 +61,7 @@
       - name: "09 Configure disk"
         ansible.builtin.command: >-
           qm set {{ proxinvoke.vmid }}
-          --scsi0 {{ proxinvoke.storage }}:{{ proxinvoke.disk_size | regex_replace('[^0-9]', '') }},discard=on
+          --scsi0 {{ proxinvoke.storage }}:{{ proxinvoke.disk_size | regex_replace('[^0-9]', '') | int }},discard=on
         when: proxinvoke.vmid|string not in qm_list.stdout
 
     - name: "10 Start VM"


### PR DESCRIPTION
## Summary
- strip non-numeric characters from `disk_size` before passing to `qm`
- document optional `G` suffix for VM disk size in README

## Testing
- `ansible-playbook --syntax-check dto_proxinvoke.yml` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689db6ff5ec08333b784b1273bf47c01