### PR TITLE
Fix indentation in Proxmox provisioning playbook

### DIFF
--- a/dto_proxinvoke.yml
+++ b/dto_proxinvoke.yml
@@ -58,11 +58,11 @@
         {% endif %}
       when: proxinvoke.vmid|string not in qm_list.stdout
 
-      - name: "09 Configure disk"
-        ansible.builtin.command: >-
-          qm set {{ proxinvoke.vmid }}
-          --scsi0 {{ proxinvoke.storage }}:{{ proxinvoke.disk_size | regex_replace('[^0-9]', '') | int }},discard=on
-        when: proxinvoke.vmid|string not in qm_list.stdout
+    - name: "09 Configure disk"
+      ansible.builtin.command: >-
+        qm set {{ proxinvoke.vmid }}
+        --scsi0 {{ proxinvoke.storage }}:{{ proxinvoke.disk_size | regex_replace('[^0-9]', '') | int }},discard=on
+      when: proxinvoke.vmid|string not in qm_list.stdout
 
     - name: "10 Start VM"
       ansible.builtin.command: "qm start {{ proxinvoke.vmid }}"


### PR DESCRIPTION
## Summary
- align `09 Configure disk` task indentation in `dto_proxinvoke.yml`

## Testing
- `ansible-playbook --syntax-check dto_proxinvoke.yml` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*
- `pip install ansible` *(fails: tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_689db9731a9c8333946cf0fde4b6223d