### PR TITLE
Remove lshw dependency from Proxmox report

### DIFF
--- a/dto_proxreport.yml
+++ b/dto_proxreport.yml
@@ -49,41 +49,43 @@
       ansible.builtin.debug:
         var: block_devices.stdout_lines
 
-    - name: "11 Ensure lshw is installed"
-      ansible.builtin.package:
-        name: lshw
-        state: present
-      become: true
-
-    - name: "12 Gather hardware details"
-      ansible.builtin.command: lshw -json
-      register: hardware_details
+    - name: "11 Gather CPU details"
+      ansible.builtin.command: lscpu
+      register: cpu_details
       changed_when: false
-      become: true
 
-    - name: "13 Show hardware details"
+    - name: "12 Display CPU details"
       ansible.builtin.debug:
-        var: hardware_details.stdout
+        var: cpu_details.stdout_lines
 
-    - name: "14 Get system uptime"
+    - name: "13 Gather memory details"
+      ansible.builtin.command: free -h
+      register: memory_details
+      changed_when: false
+
+    - name: "14 Display memory details"
+      ansible.builtin.debug:
+        var: memory_details.stdout_lines
+
+    - name: "15 Get system uptime"
       ansible.builtin.command: uptime -p
       register: uptime
       changed_when: false
 
-    - name: "15 Show system uptime"
+    - name: "16 Show system uptime"
       ansible.builtin.debug:
         var: uptime.stdout
 
-    - name: "16 List virtual machines"
+    - name: "17 List virtual machines"
       ansible.builtin.command: qm list
       register: vm_list
       changed_when: false
 
-    - name: "17 Show virtual machines"
+    - name: "18 Show virtual machines"
       ansible.builtin.debug:
         var: vm_list.stdout_lines
 
-    - name: "18 Collect data for report"
+    - name: "19 Collect data for report"
       ansible.builtin.set_fact:
         proxreport_data:
           storage_status: "{{ storage_status.stdout_lines }}"
@@ -91,13 +93,14 @@
           ip_addresses: "{{ ip_addr_output.stdout_lines }}"
           pve_version: "{{ pve_version.stdout_lines }}"
           block_devices: "{{ block_devices.stdout_lines }}"
-          hardware_details: "{{ hardware_details.stdout }}"
+          cpu_details: "{{ cpu_details.stdout_lines }}"
+          memory_details: "{{ memory_details.stdout_lines }}"
           uptime: "{{ uptime.stdout }}"
           creation_date: "{{ ansible_date_time.iso8601 }}"
           vm_list: "{{ vm_list.stdout_lines }}"
         cacheable: true
 
-    - name: Build Proxmox summary HTML
+    - name: "20 Build Proxmox summary HTML"
       ansible.builtin.template:
         src: templates/proxmox_summary.html.j2
         dest: proxmox-summary.html

--- a/templates/proxmox_summary.html.j2
+++ b/templates/proxmox_summary.html.j2
@@ -31,8 +31,11 @@
     <h2>Block devices</h2>
     <pre>{{ hostvars[host].proxreport_data.block_devices | join('\n') }}</pre>
 
-    <h2>Hardware details</h2>
-    <pre>{{ hostvars[host].proxreport_data.hardware_details }}</pre>
+    <h2>CPU details</h2>
+    <pre>{{ hostvars[host].proxreport_data.cpu_details | join('\n') }}</pre>
+
+    <h2>Memory details</h2>
+    <pre>{{ hostvars[host].proxreport_data.memory_details | join('\n') }}</pre>
 
     <h2>Virtual machines</h2>
     <pre>{{ hostvars[host].proxreport_data.vm_list | join('\n') }}</pre>

--- a/templates/proxmox_summary.md.j2
+++ b/templates/proxmox_summary.md.j2
@@ -18,8 +18,11 @@ Uptime: {{ hostvars[host].proxreport_data.uptime }}
 ## Block devices
 {{ hostvars[host].proxreport_data.block_devices | join('\\n') }}
 
-## Hardware details
-{{ hostvars[host].proxreport_data.hardware_details }}
+## CPU details
+{{ hostvars[host].proxreport_data.cpu_details | join('\\n') }}
+
+## Memory details
+{{ hostvars[host].proxreport_data.memory_details | join('\\n') }}
 
 ## Virtual machines
 {{ hostvars[host].proxreport_data.vm_list | join('\\n') }}


### PR DESCRIPTION
## Summary
- collect CPU and memory information with `lscpu` and `free -h`
- drop `lshw` requirement from Proxmox reporting playbook
- show CPU and memory details in summary templates

## Testing
- `ansible-playbook --syntax-check dto_proxreport.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc173a5548333a70342122dd6a740