### PR TITLE
Add SMBIOS type1 configuration to proxinvoke

### DIFF
--- a/dto_proxinvoke.yml
+++ b/dto_proxinvoke.yml
@@ -53,6 +53,9 @@
         --memory {{ proxinvoke.memory }}
         --cores {{ proxinvoke.cores }}
         --net0 {{ proxinvoke.networks[0] }}
+        {% if proxinvoke.smbios1 is defined %}
+        --smbios1 uuid={{ proxinvoke.smbios1.uuid }},manufacturer={{ proxinvoke.smbios1.manufacturer | quote }},product={{ proxinvoke.smbios1.product | quote }}
+        {% endif %}
       when: proxinvoke.vmid|string not in qm_list.stdout
 
     - name: "09 Configure disk"
@@ -61,16 +64,22 @@
         --scsi0 {{ proxinvoke.storage }}:{{ proxinvoke.disk_size }},discard=on
       when: proxinvoke.vmid|string not in qm_list.stdout
 
-    - name: "10 Start VM"
+    - name: "10 Set SMBIOS parameters"
+      ansible.builtin.command: >-
+        qm set {{ proxinvoke.vmid }}
+        --smbios1 uuid={{ proxinvoke.smbios1.uuid }},manufacturer={{ proxinvoke.smbios1.manufacturer | quote }},product={{ proxinvoke.smbios1.product | quote }}
+      when: proxinvoke.smbios1 is defined
+
+    - name: "11 Start VM"
       ansible.builtin.command: "qm start {{ proxinvoke.vmid }}"
       when: proxinvoke.vmid|string not in qm_list.stdout
 
-    - name: "11 Show VM status"
+    - name: "12 Show VM status"
       ansible.builtin.command: "qm status {{ proxinvoke.vmid }}"
       register: vm_status
       changed_when: false
 
-    - name: "12 Display VM status"
+    - name: "13 Display VM status"
       ansible.builtin.debug:
         var: vm_status.stdout_lines
 

--- a/templates/proxinvoke/192.168.188.101.yml.j2
+++ b/templates/proxinvoke/192.168.188.101.yml.j2
@@ -28,3 +28,9 @@ memory: 5000
 # Netzwerkdefinitionen. Weitere Einträge können ergänzt werden.
 networks:
   - virtio,bridge=vmbr0
+
+# SMBIOS (type1) configuration for the VM.
+smbios1:
+  uuid: 2c269505-717e-490b-a1cb-a089cc71e9c8
+  manufacturer: "Dell Inc."
+  product: "PowerEdge R730"


### PR DESCRIPTION
## Summary
- quote Dell R730 SMBIOS values in `qm create`
- apply SMBIOS parameters with `qm set` so new and existing VMs receive them

## Testing
- `ansible-playbook dto_proxinvoke.yml --syntax-check` *(fails: command not found)*
- `pip install ansible-core` *(fails: Cannot connect to proxy, 403)*

------
https://chatgpt.com/codex/tasks/task_e_689dafeb97348333b081efd90e0f5794