### PR TITLE
Handle trailing period in SMBIOS manufacturer

### DIFF
--- a/dto_proxinvoke.yml
+++ b/dto_proxinvoke.yml
@@ -54,7 +54,7 @@
         --cores {{ proxinvoke.cores }}
         --net0 {{ proxinvoke.networks[0] }}
         {% if proxinvoke.smbios1 is defined %}
-        --smbios1 uuid={{ proxinvoke.smbios1.uuid }},manufacturer={{ proxinvoke.smbios1.manufacturer | regex_replace(' ', '\\s') }},product={{ proxinvoke.smbios1.product | regex_replace(' ', '\\s') }}
+        --smbios1 uuid={{ proxinvoke.smbios1.uuid }},manufacturer={{ proxinvoke.smbios1.manufacturer | regex_replace('\\.$', '') | regex_replace(' ', '\\s') }},product={{ proxinvoke.smbios1.product | regex_replace(' ', '\\s') }}
         --args '-smbios type=1,uuid={{ proxinvoke.smbios1.uuid }},manufacturer="{{ proxinvoke.smbios1.manufacturer }}",product="{{ proxinvoke.smbios1.product }}"'
         {% endif %}
       when: proxinvoke.vmid|string not in qm_list.stdout
@@ -68,7 +68,7 @@
     - name: "10 Set SMBIOS parameters"
       ansible.builtin.command: >-
         qm set {{ proxinvoke.vmid }}
-        --smbios1 uuid={{ proxinvoke.smbios1.uuid }},manufacturer={{ proxinvoke.smbios1.manufacturer | regex_replace(' ', '\\s') }},product={{ proxinvoke.smbios1.product | regex_replace(' ', '\\s') }}
+        --smbios1 uuid={{ proxinvoke.smbios1.uuid }},manufacturer={{ proxinvoke.smbios1.manufacturer | regex_replace('\\.$', '') | regex_replace(' ', '\\s') }},product={{ proxinvoke.smbios1.product | regex_replace(' ', '\\s') }}
       when: proxinvoke.smbios1 is defined
 
     - name: "11 Check VM status"


### PR DESCRIPTION
## Summary
- Strip trailing period from SMBIOS manufacturer before escaping spaces to satisfy Proxmox validation

## Testing
- ❌ `ansible-playbook --syntax-check dto_proxinvoke.yml` (ansible-playbook: command not found)
- ❌ `yamllint dto_proxinvoke.yml` (yamllint: command not found)


------
https://chatgpt.com/codex/tasks/task_e_689dd487d07083339ae1d3ac21c8c778